### PR TITLE
add: license and standard-readme badges in maximal example

### DIFF
--- a/example-readmes/maximal-readme.md
+++ b/example-readmes/maximal-readme.md
@@ -4,6 +4,8 @@
 
 ![badge]()
 ![badge]()
+[![license](https://img.shields.io/github/license/:user/:repo.svg)](LICENSE)
+[![standard-readme compliant](https://img.shields.io/badge/readme%20style-standard-brightgreen.svg?style=flat-square)](https://github.com/RichardLitt/standard-readme)
 
 > This is an example file with maximal choices selected.
 
@@ -40,6 +42,8 @@ This module depends upon a knowledge of [Markdown]().
 
 ```
 ```
+
+Note: The `license` badge image link at the top of this file should be updated with the correct `:user` and `:repo`.
 
 ### Any optional sections
 


### PR DESCRIPTION
Given that it's a *maximal* example, I think it's appropriate to include the optional `standard-readme` badge. I also added a license badge, which seems fairly widely-used and probably should fit in the *maximal* spec example.