### PR TITLE
Fix spec.md path resolution for global installation - Fixes #129

### DIFF
--- a/cat.sh
+++ b/cat.sh
@@ -1,3 +1,7 @@
 #! /bin/bash
 
-cat spec.md
+# Get the directory where this script is located
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Cat the spec.md file from the script's directory
+cat "${SCRIPT_DIR}/spec.md"


### PR DESCRIPTION
Fixes #129 - Resolves path issue when running standard-readme-spec globally